### PR TITLE
Fix mac and linux paths using ~

### DIFF
--- a/Exporters/Lazer/LazerLoader.cs
+++ b/Exporters/Lazer/LazerLoader.cs
@@ -23,7 +23,7 @@ namespace BeatmapExporter.Exporters.Lazer
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "~/.osu/Songs");
+                    directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".osu/Songs");
                 }
                 else
                 {

--- a/Exporters/Lazer/LazerLoader.cs
+++ b/Exporters/Lazer/LazerLoader.cs
@@ -23,11 +23,11 @@ namespace BeatmapExporter.Exporters.Lazer
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    directory = "~/.osu/Songs";
+                    directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "~/.osu/Songs");
                 }
                 else
                 {
-                    directory = "~/.local/share/osu";
+                    directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local/share/osu");
                 }
             }
 


### PR DESCRIPTION
Mac and Linux paths used ~ in the path, which is not expanded in C#. Replaced with Environment.SpecialFolder.UserProfile which resolves to the user's home directory.