### PR TITLE
Added ability to export beatmap backgrounds

### DIFF
--- a/BeatmapExporter.cs
+++ b/BeatmapExporter.cs
@@ -27,7 +27,7 @@ namespace BeatmapExporter
         void ApplicationLoop()
         {
             // output main application menu
-            Console.Write($"\n1. Export selected {config.ExportFormatUnitName} ({exporter.SelectedBeatmapSetCount} beatmap sets, {exporter.SelectedBeatmapCount} beatmaps)\n2. Display selected beatmap sets ({exporter.SelectedBeatmapSetCount}/{exporter.BeatmapSetCount} beatmap sets)\n3. Display {exporter.CollectionCount} beatmap collections\n4. Advanced export settings (.mp3 export, compression, export location)\n5. Edit beatmap selection/filters\n\n0. Exit\nSelect operation: ");
+            Console.Write($"\n1. Export selected {config.ExportFormatUnitName} ({exporter.SelectedBeatmapSetCount} beatmap sets, {exporter.SelectedBeatmapCount} beatmaps)\n2. Display selected beatmap sets ({exporter.SelectedBeatmapSetCount}/{exporter.BeatmapSetCount} beatmap sets)\n3. Display {exporter.CollectionCount} beatmap collections\n4. Advanced export settings (.mp3/image export, compression, export location)\n5. Edit beatmap selection/filters\n\n0. Exit\nSelect operation: ");
 
             string? input = Console.ReadLine();
             if (input is null)
@@ -87,14 +87,14 @@ namespace BeatmapExporter
                 bool exportBeatmaps = config.ExportFormat == ExporterConfiguration.Format.Beatmap;
                 switch(config.ExportFormat)
                 {
+                    case ExporterConfiguration.Format.Beatmap:
+                        settings.Append("Type 1: Beatmaps will be exported in osu! archive format (.osz)");
+                        break;
                     case ExporterConfiguration.Format.Audio:
-                        settings.Append("Beatmap audio files will be renamed, tagged and exported (.mp3 format)*");
+                        settings.Append("Type 2: Beatmap audio files will be renamed, tagged and exported (.mp3 format)*");
                         break;
                     case ExporterConfiguration.Format.Background:
-                        settings.Append("Beatmap background files will be exported (original format)");
-                        break;
-                    case ExporterConfiguration.Format.Beatmap:
-                        settings.Append("Beatmaps will be exported in osu! archive format (.osz)");
+                        settings.Append("Type 3: Only beatmap background images will be exported (original format)*");
                         break;
                 }
 

--- a/BeatmapExporter.cs
+++ b/BeatmapExporter.cs
@@ -55,6 +55,9 @@ namespace BeatmapExporter
                         case ExporterConfiguration.Format.Audio:
                             exporter.ExportAudioFiles();
                             break;
+                        case ExporterConfiguration.Format.Background:
+                            exporter.ExportBackgroundFiles();
+                            break;
                     }
                     break;
                 case 2:
@@ -86,6 +89,9 @@ namespace BeatmapExporter
                 {
                     case ExporterConfiguration.Format.Audio:
                         settings.Append("Beatmap audio files will be renamed, tagged and exported (.mp3 format)*");
+                        break;
+                    case ExporterConfiguration.Format.Background:
+                        settings.Append("Beatmap background files will be exported (original format)");
                         break;
                     case ExporterConfiguration.Format.Beatmap:
                         settings.Append("Beatmaps will be exported in osu! archive format (.osz)");
@@ -120,15 +126,17 @@ namespace BeatmapExporter
                 switch(op)
                 {
                     case 1:
-                        if(exportBeatmaps)
+                        switch (config.ExportFormat)
                         {
-                            Console.WriteLine("- CHANGED: Beatmap audio files will be renamed, tagged and exported (.mp3 format).");
-                            config.ExportFormat = ExporterConfiguration.Format.Audio;
-                        }
-                        else
-                        {
-                            Console.WriteLine("- CHANGED: Beatmaps will be exported in osu! archive format (.osz).");
-                            config.ExportFormat = ExporterConfiguration.Format.Beatmap;
+                            case ExporterConfiguration.Format.Beatmap:
+                                config.ExportFormat = ExporterConfiguration.Format.Audio;
+                                break;
+                            case ExporterConfiguration.Format.Audio:
+                                config.ExportFormat = ExporterConfiguration.Format.Background;
+                                break;
+                            case ExporterConfiguration.Format.Background:
+                                config.ExportFormat = ExporterConfiguration.Format.Beatmap;
+                                break;
                         }
                         break;
                     case 2:

--- a/Exporters/ExporterConfiguration.cs
+++ b/Exporters/ExporterConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Compression;
+using System.IO.Compression;
 
 namespace BeatmapExporter.Exporters
 {
@@ -27,7 +27,12 @@ namespace BeatmapExporter.Exporters
             get
             {
                 string basePath = exportPath is not null ? exportPath : DefaultExportPath;
-                return ExportFormat == Format.Audio ? Path.Combine(basePath, "mp3") : basePath;
+                return ExportFormat switch
+                {
+                    Format.Beatmap => basePath,
+                    Format.Audio => Path.Combine(basePath, "mp3"),
+                    Format.Background => Path.Combine(basePath, "bg")
+                };
             }
             set => exportPath = value;
         }

--- a/Exporters/ExporterConfiguration.cs
+++ b/Exporters/ExporterConfiguration.cs
@@ -1,4 +1,4 @@
-using System.IO.Compression;
+﻿using System.IO.Compression;
 
 namespace BeatmapExporter.Exporters
 {
@@ -6,7 +6,7 @@ namespace BeatmapExporter.Exporters
     {
         public static readonly string DefaultAudioPath = "mp3";
 
-        public enum Format { Audio, Beatmap, Background };  
+        public enum Format { Beatmap, Audio, Background };
 
         private readonly string defaultExportPath;
         private string? exportPath = null;
@@ -47,9 +47,9 @@ namespace BeatmapExporter.Exporters
 
         public string ExportFormatUnitName => ExportFormat switch
         {
-            Format.Audio => "audio (.mp3)",
             Format.Beatmap => "osu! beatmaps (.osz)",
-            Format.Background => "backgrounds (original)",
+            Format.Audio => "audio (.mp3)",
+            Format.Background => "beatmap backgrounds",
             _ => throw new NotImplementedException()
         };
     }

--- a/Exporters/ExporterConfiguration.cs
+++ b/Exporters/ExporterConfiguration.cs
@@ -6,7 +6,7 @@ namespace BeatmapExporter.Exporters
     {
         public static readonly string DefaultAudioPath = "mp3";
 
-        public enum Format { Audio, Beatmap };  
+        public enum Format { Audio, Beatmap, Background };  
 
         private readonly string defaultExportPath;
         private string? exportPath = null;
@@ -44,6 +44,7 @@ namespace BeatmapExporter.Exporters
         {
             Format.Audio => "audio (.mp3)",
             Format.Beatmap => "osu! beatmaps (.osz)",
+            Format.Background => "backgrounds (original)",
             _ => throw new NotImplementedException()
         };
     }

--- a/Exporters/IBeatmapExporter.cs
+++ b/Exporters/IBeatmapExporter.cs
@@ -19,6 +19,7 @@ namespace BeatmapExporter.Exporters
         void DisplaySelectedBeatmaps();
         void ExportBeatmaps();
         void ExportAudioFiles();
+        void ExportBackgroundFiles();
         void DisplayCollections();
     }
 }

--- a/Exporters/Lazer/LazerDB/Schema/BeatmapMetadata.cs
+++ b/Exporters/Lazer/LazerDB/Schema/BeatmapMetadata.cs
@@ -17,8 +17,21 @@ namespace BeatmapExporter.Exporters.Lazer.LazerDB.Schema
         public string BackgroundFile { get; set; } = string.Empty;
 
         // Author kabii
+        private string OutputName(int beatmapId) => $"{Artist.Trunc(30)} - {Title.Trunc(60)} ({beatmapId})";
+
         public string OutputAudioFilename(int beatmapId) =>
-            $"{Artist.Trunc(30)} - {Title.Trunc(60)} ({beatmapId}).mp3"
+            $"{OutputName(beatmapId)}.mp3"
             .RemoveFilenameCharacters();
+
+        public string OutputBackgroundFilename(int beatmapId)
+        {
+            var backgroundName = BackgroundFile.Trunc(120);
+            if (BackgroundFile != backgroundName)
+                // restore file extension if truncated
+                backgroundName = backgroundName + Path.GetExtension(BackgroundFile);
+            return 
+                $"{OutputName(beatmapId)} {backgroundName}"
+                .RemoveFilenameCharacters();
+        }
     }
 }

--- a/Exporters/Lazer/LazerExporter.cs
+++ b/Exporters/Lazer/LazerExporter.cs
@@ -1,4 +1,4 @@
-using BeatmapExporter.Exporters.Lazer.LazerDB;
+﻿using BeatmapExporter.Exporters.Lazer.LazerDB;
 using BeatmapExporter.Exporters.Lazer.LazerDB.Schema;
 using System.IO.Compression;
 using System.Text;
@@ -312,10 +312,11 @@ namespace BeatmapExporter.Exporters.Lazer
             int attempted = 0;
             foreach (var mapset in selectedBeatmapSets)
             {
-                // same filter as audio
+                // get beatmap diffs from this set with different background image filenames
                 var uniqueMetadata = mapset
                     .SelectedBeatmaps
                     .Select(b => b.Metadata)
+                    .Where(m => m.BackgroundFile != null)
                     .GroupBy(m => m.BackgroundFile)
                     .Select(g => g.First())
                     .ToList();

--- a/Exporters/Lazer/LazerExporter.cs
+++ b/Exporters/Lazer/LazerExporter.cs
@@ -1,4 +1,4 @@
-﻿using BeatmapExporter.Exporters.Lazer.LazerDB;
+using BeatmapExporter.Exporters.Lazer.LazerDB;
 using BeatmapExporter.Exporters.Lazer.LazerDB.Schema;
 using System.IO.Compression;
 using System.Text;
@@ -324,8 +324,8 @@ namespace BeatmapExporter.Exporters.Lazer
                 {
                     try
                     {
-                        //same naming format as audio but with filename as mapset ids may have the same background file
-                        string outputFilename = $"{Path.GetFileNameWithoutExtension(metadata.OutputAudioFilename(mapset.OnlineID))} {metadata.BackgroundFile}";
+                        // get output filename for background including original background name
+                        string outputFilename = metadata.OutputBackgroundFilename(mapset.OnlineID);
                         string outputFile = Path.Combine(exportDir, outputFilename);
 
                         attempted++;
@@ -342,7 +342,7 @@ namespace BeatmapExporter.Exporters.Lazer
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine($"Unable to export beatmap :: {e.Message}");
+                        Console.WriteLine($"Unable to export background image :: {e.Message}");
                     }
                 }
             }


### PR DESCRIPTION
Change to add exporting selected beatmaps backgrounds in their original format. Basically uses the same code as the audio export. The names of the background files have the original filenames appended at the end becuase I encountered an issue with image files overwriting eachother.

With original filename extention added:
![image](https://github.com/kabiiQ/BeatmapExporter/assets/119447648/b04f38ff-6283-4b10-a3ba-43eb8ffa28e9)

Without extention added:
![image](https://github.com/kabiiQ/BeatmapExporter/assets/119447648/d0cda1e5-0601-4aa6-80ed-ad9e69607251)
