### PR TITLE
Adding local replay/score export with lazer naming

### DIFF
--- a/BeatmapExporter.cs
+++ b/BeatmapExporter.cs
@@ -27,7 +27,7 @@ namespace BeatmapExporter
         void ApplicationLoop()
         {
             // output main application menu
-            Console.Write($"\n1. Export selected {config.ExportFormatUnitName} ({exporter.SelectedBeatmapSetCount} beatmap sets, {exporter.SelectedBeatmapCount} beatmaps)\n2. Display selected beatmap sets ({exporter.SelectedBeatmapSetCount}/{exporter.BeatmapSetCount} beatmap sets)\n3. Display {exporter.CollectionCount} beatmap collections\n4. Advanced export settings (.mp3/image export, compression, export location)\n5. Edit beatmap selection/filters\n\n0. Exit\nSelect operation: ");
+            Console.Write($"\n1. Export selected {config.ExportFormatUnitName} ({exporter.SelectedBeatmapSetCount} beatmap sets, {exporter.SelectedBeatmapCount} beatmaps)\n2. Display selected beatmap sets ({exporter.SelectedBeatmapSetCount}/{exporter.BeatmapSetCount} beatmap sets)\n3. Display {exporter.CollectionCount} beatmap collections\n4. Advanced export settings (.mp3/image/score export, compression, export location)\n5. Edit beatmap selection/filters\n\n0. Exit\nSelect operation: ");
 
             string? input = Console.ReadLine();
             if (input is null)
@@ -57,6 +57,9 @@ namespace BeatmapExporter
                             break;
                         case ExporterConfiguration.Format.Background:
                             exporter.ExportBackgroundFiles();
+                            break;
+                        case ExporterConfiguration.Format.Score:
+                            exporter.ExportScores();
                             break;
                     }
                     break;
@@ -95,6 +98,9 @@ namespace BeatmapExporter
                         break;
                     case ExporterConfiguration.Format.Background:
                         settings.Append("Type 3: Only beatmap background images will be exported (original format)*");
+                        break;
+                    case ExporterConfiguration.Format.Score:
+                        settings.Append("Type 4: Only scores will be exported (.osr)*");
                         break;
                 }
 
@@ -135,6 +141,9 @@ namespace BeatmapExporter
                                 config.ExportFormat = ExporterConfiguration.Format.Background;
                                 break;
                             case ExporterConfiguration.Format.Background:
+                                config.ExportFormat = ExporterConfiguration.Format.Score;
+                                break;
+                            case ExporterConfiguration.Format.Score:
                                 config.ExportFormat = ExporterConfiguration.Format.Beatmap;
                                 break;
                         }

--- a/BeatmapExporter.csproj
+++ b/BeatmapExporter.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FFMpegCore" Version="5.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Realm" Version="10.21.1" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
   </ItemGroup>

--- a/Exporters/ExporterConfiguration.cs
+++ b/Exporters/ExporterConfiguration.cs
@@ -6,7 +6,7 @@ namespace BeatmapExporter.Exporters
     {
         public static readonly string DefaultAudioPath = "mp3";
 
-        public enum Format { Beatmap, Audio, Background };
+        public enum Format { Beatmap, Audio, Background, Score };
 
         private readonly string defaultExportPath;
         private string? exportPath = null;
@@ -31,7 +31,8 @@ namespace BeatmapExporter.Exporters
                 {
                     Format.Beatmap => basePath,
                     Format.Audio => Path.Combine(basePath, "mp3"),
-                    Format.Background => Path.Combine(basePath, "bg")
+                    Format.Background => Path.Combine(basePath, "bg"),
+                    Format.Score => Path.Combine(basePath, "osr")
                 };
             }
             set => exportPath = value;
@@ -50,6 +51,7 @@ namespace BeatmapExporter.Exporters
             Format.Beatmap => "osu! beatmaps (.osz)",
             Format.Audio => "audio (.mp3)",
             Format.Background => "beatmap backgrounds",
+            Format.Score => "osu! scores (.osr)",
             _ => throw new NotImplementedException()
         };
     }

--- a/Exporters/IBeatmapExporter.cs
+++ b/Exporters/IBeatmapExporter.cs
@@ -20,6 +20,7 @@ namespace BeatmapExporter.Exporters
         void ExportBeatmaps();
         void ExportAudioFiles();
         void ExportBackgroundFiles();
+        void ExportScores();
         void DisplayCollections();
     }
 }

--- a/Exporters/Lazer/LazerDB/LazerDatabase.cs
+++ b/Exporters/Lazer/LazerDB/LazerDatabase.cs
@@ -1,6 +1,7 @@
 ﻿using BeatmapExporter.Exporters.Lazer.LazerDB.Schema;
 using Realms;
 using Realms.Exceptions;
+using Test.schemas;
 
 namespace BeatmapExporter.Exporters.Lazer.LazerDB
 {
@@ -55,7 +56,8 @@ namespace BeatmapExporter.Exporters.Lazer.LazerDB
                 typeof(RealmNamedFileUsage),
                 typeof(RealmUser),
                 typeof(Ruleset),
-                typeof(ModPreset)
+                typeof(ModPreset),
+                typeof(ScoreInfo)
             };
 
             try

--- a/Exporters/Lazer/LazerDB/LazerDatabase.cs
+++ b/Exporters/Lazer/LazerDB/LazerDatabase.cs
@@ -1,7 +1,6 @@
 ﻿using BeatmapExporter.Exporters.Lazer.LazerDB.Schema;
 using Realms;
 using Realms.Exceptions;
-using Test.schemas;
 
 namespace BeatmapExporter.Exporters.Lazer.LazerDB
 {

--- a/Exporters/Lazer/LazerDB/Schema/APIUser.cs
+++ b/Exporters/Lazer/LazerDB/Schema/APIUser.cs
@@ -5,7 +5,7 @@
 
 using Newtonsoft.Json;
 
-namespace Test
+namespace BeatmapExporter.Exporters.Lazer.LazerDB.Schema
 {
     [JsonObject(MemberSerialization.OptIn)]
     public class APIUser 

--- a/Exporters/Lazer/LazerDB/Schema/APIUser.cs
+++ b/Exporters/Lazer/LazerDB/Schema/APIUser.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using Newtonsoft.Json;
+
+namespace Test
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class APIUser 
+    {   
+        [JsonProperty(@"username")]
+        public string Username { get; set; } = string.Empty;
+    }
+}

--- a/Exporters/Lazer/LazerDB/Schema/Beatmap.cs
+++ b/Exporters/Lazer/LazerDB/Schema/Beatmap.cs
@@ -2,7 +2,6 @@
 
 using Newtonsoft.Json;
 using Realms;
-using Test.schemas;
 
 namespace BeatmapExporter.Exporters.Lazer.LazerDB.Schema
 {

--- a/Exporters/Lazer/LazerDB/Schema/Beatmap.cs
+++ b/Exporters/Lazer/LazerDB/Schema/Beatmap.cs
@@ -1,5 +1,8 @@
 ﻿// Original source file (modified by kabii) Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+
+using Newtonsoft.Json;
 using Realms;
+using Test.schemas;
 
 namespace BeatmapExporter.Exporters.Lazer.LazerDB.Schema
 {
@@ -15,6 +18,10 @@ namespace BeatmapExporter.Exporters.Lazer.LazerDB.Schema
         public BeatmapDifficulty Difficulty { get; set; } = null!;
 
         public BeatmapMetadata Metadata { get; set; } = null!;
+        
+        [JsonIgnore]
+        [Backlink(nameof(ScoreInfo.BeatmapInfo))]
+        public IQueryable<ScoreInfo> Scores { get; } = null!;
 
         public BeatmapUserSettings UserSettings { get; set; } = null!;
 

--- a/Exporters/Lazer/LazerDB/Schema/Beatmap.cs
+++ b/Exporters/Lazer/LazerDB/Schema/Beatmap.cs
@@ -90,5 +90,13 @@ namespace BeatmapExporter.Exporters.Lazer.LazerDB.Schema
         {
             return HashCode.Combine(base.GetHashCode(), ID);
         }
+        
+        //GetDisplayTitle() step in (from lazer's BeatmapInfoExtensions) to stay consistent with lazer's naming
+        public string Display()
+        {
+            return $"{this.Metadata.Display()} {GetVersionString()}".Trim();
+        }
+        //GetVersionString() step in (from lazer's BeatmapInfoExtensions)
+        private string GetVersionString() => string.IsNullOrEmpty(this.DifficultyName) ? string.Empty : $"[{this.DifficultyName}]";
     }
 }

--- a/Exporters/Lazer/LazerDB/Schema/BeatmapMetadata.cs
+++ b/Exporters/Lazer/LazerDB/Schema/BeatmapMetadata.cs
@@ -33,5 +33,16 @@ namespace BeatmapExporter.Exporters.Lazer.LazerDB.Schema
                 $"{OutputName(beatmapId)} {backgroundName}"
                 .RemoveFilenameCharacters();
         }
+        
+        //GetDisplayTitle() step in (from lazer's BeatmapMetadataExtensions) to stay consistent with lazer's naming
+        public string Display()
+        {
+            string author = string.IsNullOrEmpty(this.Author.Username) ? string.Empty : $" ({this.Author.Username})";
+
+            string artist = string.IsNullOrEmpty(this.Artist) ? "unknown artist" : this.Artist;
+            string title = string.IsNullOrEmpty(this.Title) ? "unknown title" : this.Title;
+
+            return $"{artist} - {title}{author}".Trim();
+        }
     }
 }

--- a/Exporters/Lazer/LazerDB/Schema/ScoreInfo.cs
+++ b/Exporters/Lazer/LazerDB/Schema/ScoreInfo.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using BeatmapExporter;
-using BeatmapExporter.Exporters.Lazer.LazerDB.Schema;
 using Realms;
 
-namespace Test.schemas
+namespace BeatmapExporter.Exporters.Lazer.LazerDB.Schema
 {
     /// <summary>
     /// A realm model containing metadata for a single score.

--- a/Exporters/Lazer/LazerDB/Schema/ScoreInfo.cs
+++ b/Exporters/Lazer/LazerDB/Schema/ScoreInfo.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BeatmapExporter.Exporters.Lazer.LazerDB.Schema;
+using Realms;
+
+namespace Test.schemas
+{
+    /// <summary>
+    /// A realm model containing metadata for a single score.
+    /// </summary>
+    [MapTo("Score")]
+    public class ScoreInfo : RealmObject
+    {
+        [PrimaryKey]
+        public Guid ID { get; set; }
+        
+        public Beatmap? BeatmapInfo { get; set; }
+        
+        public DateTimeOffset Date { get; set; }
+        
+        [MapTo("User")]
+        public RealmUser RealmUser { get; set; } = null!;
+        
+        //could not find a username attached to score besides this way
+        private APIUser? user;
+
+        [Ignored]
+        public APIUser User =>
+            user ??= new APIUser
+            {
+                Username = RealmUser.Username
+            };
+
+        //GetDisplayTitle() step in (from lazer's ScoreInfoExtensions) to stay consistent with lazer's naming
+        //Display methods can be removed and replaced with a realm property if following lazer's naming is not important 
+        public string Display() => $"{this.User.Username} playing {this.BeatmapInfo?.Display() ?? "unknown"}";
+        
+        public string ArchiveFilename()
+        {
+            string scoreString = this.Display();
+            string filename = $"{scoreString} ({this.Date.LocalDateTime:yyyy-MM-dd_HH-mm})";
+
+            return filename;
+        }
+    }
+}

--- a/Exporters/Lazer/LazerDB/Schema/ScoreInfo.cs
+++ b/Exporters/Lazer/LazerDB/Schema/ScoreInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using BeatmapExporter;
 using BeatmapExporter.Exporters.Lazer.LazerDB.Schema;
 using Realms;
 
@@ -17,6 +18,9 @@ namespace Test.schemas
         
         public Beatmap? BeatmapInfo { get; set; }
         
+        public string BeatmapHash { get; set; } = string.Empty;
+
+        public IList<RealmNamedFileUsage> Files { get; } = null!;
         public DateTimeOffset Date { get; set; }
         
         [MapTo("User")]
@@ -36,12 +40,13 @@ namespace Test.schemas
         //Display methods can be removed and replaced with a realm property if following lazer's naming is not important 
         public string Display() => $"{this.User.Username} playing {this.BeatmapInfo?.Display() ?? "unknown"}";
         
-        public string ArchiveFilename()
+        public string OutputScoreFilename()
         {
             string scoreString = this.Display();
-            string filename = $"{scoreString} ({this.Date.LocalDateTime:yyyy-MM-dd_HH-mm})";
-
-            return filename;
+            string filename = $"{scoreString} ({this.Date.LocalDateTime:yyyy-MM-dd_HH-mm}).osr";
+            
+            return filename.RemoveFilenameCharacters();
         }
+        
     }
 }

--- a/Exporters/Lazer/LazerExporter.cs
+++ b/Exporters/Lazer/LazerExporter.cs
@@ -412,18 +412,17 @@ namespace BeatmapExporter.Exporters.Lazer
                         }
                         catch (Exception e)
                         {
-                            Console.WriteLine($"Unable to export {filename} :: {e.Message}");
+                            Console.WriteLine($"Unable to export score {filename} :: {e.Message}");
                         }
                         finally
                         {
                             export?.Dispose();
                         }
                     }
-
-                    string location = Path.GetFullPath(exportDir);
-                    Console.WriteLine($"Exported {exported}/{selectedScoreCount} scores to {location}.");
                 }
             }
+            string location = Path.GetFullPath(exportDir);
+            Console.WriteLine($"Exported {exported}/{selectedScoreCount} scores to {location}.");
         }
     
         public void DisplayCollections()


### PR DESCRIPTION
There is already a way to export local scores in lazer manually, but it is pretty slow. Adding this branch will require adding some sort of JSON serilizer library dependency (I picked Newtonsoft because it's the same as lazer), but it is only used to access the username in the score to follow lazer's naming so it can be removed if file naming is not important.

Screenshot of results:
![image](https://github.com/kabiiQ/BeatmapExporter/assets/119447648/d1c26603-8b0b-41fb-a04f-c832db943eae)
