### PR TITLE
Feature: add by date sorting

### DIFF
--- a/BeatmapExporterCLI/Interface/LazerExporterCLI.cs
+++ b/BeatmapExporterCLI/Interface/LazerExporterCLI.cs
@@ -1,5 +1,6 @@
 ﻿using BeatmapExporterCore.Exporters;
 using BeatmapExporterCore.Exporters.Lazer;
+using BeatmapExporterCore.Exporters.Lazer.LazerDB.Schema;
 using BeatmapExporterCore.Filters;
 using System.Text;
 
@@ -21,14 +22,21 @@ namespace BeatmapExporterCLI.Interface
         public LazerExporter Exporter { get; }
 
         public ExporterConfiguration Configuration => Exporter.Configuration;
-         
+
+        // When Configuration.SortByDateAdded is on, iterate selected sets by DateAdded ascending
+        // with the set ID as a stable tiebreaker. Otherwise preserve the LazerExporter default order.
+        private IEnumerable<BeatmapSet> OrderedSelectedSets() =>
+            Configuration.SortByDateAdded
+                ? Exporter.SelectedBeatmapSets.OrderBy(s => s.DateAdded).ThenBy(s => s.ID)
+                : Exporter.SelectedBeatmapSets;
+
         public void ExportBeatmaps()
         {
             Exporter.SetupExport();
             int attempted = 0, exported = 0;
             int count = Exporter.SelectedBeatmapSetCount;
             Console.WriteLine($"Selected {Exporter.SelectedBeatmapSetCount} beatmap sets for export.");
-            foreach (var mapset in Exporter.SelectedBeatmapSets)
+            foreach (var mapset in OrderedSelectedSets())
             {
                 string? filename = null;
                 attempted++;
@@ -62,7 +70,7 @@ namespace BeatmapExporterCLI.Interface
             Console.WriteLine(Exporter.AudioTranscodeInfo());
 
             int attempted = 0, exportedAudio = 0;
-            foreach (var mapset in Exporter.SelectedBeatmapSets)
+            foreach (var mapset in OrderedSelectedSets())
             {
                 var allAudio = Exporter.ExtractAudio(mapset);
                 
@@ -105,7 +113,7 @@ namespace BeatmapExporterCLI.Interface
             Console.WriteLine($"Exporting beatmap background images from {Exporter.SelectedBeatmapSetCount}.");
 
             int attempted = 0, exported = 0;
-            foreach (var mapset in Exporter.SelectedBeatmapSets)
+            foreach (var mapset in OrderedSelectedSets())
             {
                 var allImages = Exporter.ExtractBackgrounds(mapset);
 
@@ -135,7 +143,9 @@ namespace BeatmapExporterCLI.Interface
             Exporter.SetupExport();
             int exported = 0;
 
-            var selectedReplays = Exporter.GetSelectedReplays();
+            var selectedReplays = OrderedSelectedSets()
+                .SelectMany(s => s.SelectedBeatmaps)
+                .SelectMany(b => b.Scores);
             var replayCount = selectedReplays.Count();
 
             Console.WriteLine($"Exporting {replayCount} replays from {Exporter.SelectedBeatmapCount} selected beatmaps.");
@@ -203,7 +213,7 @@ namespace BeatmapExporterCLI.Interface
 
         public void DisplaySelectedBeatmaps()
         {
-            foreach (var map in Exporter.SelectedBeatmapSets)
+            foreach (var map in OrderedSelectedSets())
             {
                 Console.WriteLine(map.DiffSummary());
             }
@@ -274,11 +284,17 @@ namespace BeatmapExporterCLI.Interface
                         settings.Append("audio files will be exported in their original file format*");
                 }
 
+                settings.Append("\n5. ");
+                if (Configuration.SortByDateAdded)
+                    settings.Append("export sort: by date added (oldest first)*");
+                else
+                    settings.Append("export sort: default (by online beatmap ID)");
+
                 settings.Append("\n\nEdit setting # (Blank to save settings): ");
 
                 Console.Write(settings.ToString());
                 string? input = Console.ReadLine();
-                if (string.IsNullOrEmpty(input) || !int.TryParse(input, out int op) || op < 1 || op > (exportBeatmaps || exportCollectionDb || exportAudio ? 4 : 2))
+                if (string.IsNullOrEmpty(input) || !int.TryParse(input, out int op) || op < 1 || op > 5)
                 {
                     Console.Write("\nInvalid operation selected.\n");
                     return;
@@ -350,6 +366,12 @@ namespace BeatmapExporterCLI.Interface
                                 Configuration.MergeCaseInsensitive = true;
                             }
                         }
+                        break;
+                    case 5:
+                        Configuration.SortByDateAdded = !Configuration.SortByDateAdded;
+                        Console.WriteLine(Configuration.SortByDateAdded
+                            ? "- CHANGED: export will be sorted by date added (oldest first)."
+                            : "- CHANGED: export will use the default order (by online beatmap ID).");
                         break;
                 }
             }

--- a/BeatmapExporterCLI/Interface/LazerExporterCLI.cs
+++ b/BeatmapExporterCLI/Interface/LazerExporterCLI.cs
@@ -284,17 +284,21 @@ namespace BeatmapExporterCLI.Interface
                         settings.Append("audio files will be exported in their original file format*");
                 }
 
-                settings.Append("\n5. ");
-                if (Configuration.SortByDateAdded)
-                    settings.Append("export sort: by date added (oldest first)*");
-                else
-                    settings.Append("export sort: default (by online beatmap ID)");
+                var sortApplicable = Configuration.ExportFormat is not (ExportFormat.Skins or ExportFormat.CollectionDb);
+                if (sortApplicable)
+                {
+                    settings.Append("\n5. ");
+                    if (Configuration.SortByDateAdded)
+                        settings.Append("export sort: by date added (oldest first)*");
+                    else
+                        settings.Append("export sort: default (by online beatmap ID)");
+                }
 
                 settings.Append("\n\nEdit setting # (Blank to save settings): ");
 
                 Console.Write(settings.ToString());
                 string? input = Console.ReadLine();
-                if (string.IsNullOrEmpty(input) || !int.TryParse(input, out int op) || op < 1 || op > 5)
+                if (string.IsNullOrEmpty(input) || !int.TryParse(input, out int op) || op < 1 || op > (sortApplicable ? 5 : 4))
                 {
                     Console.Write("\nInvalid operation selected.\n");
                     return;

--- a/BeatmapExporterCore/Exporters/ExporterConfiguration.cs
+++ b/BeatmapExporterCore/Exporters/ExporterConfiguration.cs
@@ -19,6 +19,7 @@ namespace BeatmapExporterCore.Exporters
         private bool mergeCollections;
         private bool caseInsensitiveMerge;
         private bool exportMp3;
+        private bool sortByDateAdded;
 
         public ExporterConfiguration(ClientSettings settings)
         {
@@ -48,6 +49,7 @@ namespace BeatmapExporterCore.Exporters
             mergeCollections = settings.MergeCollections;
             caseInsensitiveMerge = settings.MergeCaseInsensitive;
             exportMp3 = settings.ExportMp3;
+            sortByDateAdded = settings.SortByDateAdded;
 
             Filters = settings.AppliedFilters
                 .Select(f => f.ToBeatmapFilter())
@@ -177,6 +179,20 @@ namespace BeatmapExporterCore.Exporters
             {
                 exportMp3 = value;
                 settings.SaveExportMp3(value);
+            }
+        }
+
+        /// <summary>
+        /// If selected beatmap sets should be ordered by DateAdded (ascending) during export.
+        /// When false, export preserves the default LazerExporter ordering (by OnlineID).
+        /// </summary>
+        public bool SortByDateAdded
+        {
+            get => sortByDateAdded;
+            set
+            {
+                sortByDateAdded = value;
+                settings.SaveSortByDateAdded(value);
             }
         }
 

--- a/BeatmapExporterCore/Utilities/ClientSettings.cs
+++ b/BeatmapExporterCore/Utilities/ClientSettings.cs
@@ -51,6 +51,8 @@ namespace BeatmapExporterCore.Utilities
         
         public bool ExportMp3 { get; set; } = true;
 
+        public bool SortByDateAdded { get; set; } = false;
+
         public List<SerializedBeatmapFilter> AppliedFilters { get; set; } = [];
         #endregion
 
@@ -181,6 +183,15 @@ namespace BeatmapExporterCore.Utilities
         public void SaveExportMp3(bool mp3)
         {
             ExportMp3 = mp3;
+            TrySave();
+        }
+
+        /// <summary>
+        /// Saves the preference for sorting exported beatmap sets by date added.
+        /// </summary>
+        public void SaveSortByDateAdded(bool sort)
+        {
+            SortByDateAdded = sort;
             TrySave();
         }
 

--- a/BeatmapExporterGUI/ViewModels/ExportViewModel.cs
+++ b/BeatmapExporterGUI/ViewModels/ExportViewModel.cs
@@ -81,6 +81,12 @@ namespace BeatmapExporterGUI.ViewModels
 
         private void AddExport(bool success, string description) => Exported.Insert(0, new(success, description));
 
+        // Mirror of LazerExporterCLI.OrderedSelectedSets — applies the configured export sort.
+        private IEnumerable<BeatmapSet> OrderedSelectedSets() =>
+            lazer.Configuration.SortByDateAdded
+                ? lazer.SelectedBeatmapSets.OrderBy(s => s.DateAdded).ThenBy(s => s.ID)
+                : lazer.SelectedBeatmapSets;
+
         /// <summary>
         /// Identifies the requested export format and begins the export operation represented by this ExportView. 
         /// </summary>
@@ -118,7 +124,9 @@ namespace BeatmapExporterGUI.ViewModels
             TotalCount = TotalSetCount;
             int exported = 0;
             Description = $"{TotalSetCount} beatmap sets ({lazer.SelectedBeatmapCount} diffs) are selected for export.";
-            foreach (var mapset in lazer.SelectedBeatmapSets)
+            // Materialize the sorted set list on the Realm scheduler thread — DateAdded is realm-managed.
+            var setsToExport = await Exporter.RealmScheduler.Schedule(() => OrderedSelectedSets().ToList());
+            foreach (var mapset in setsToExport)
             {
                 if (token.IsCancellationRequested)
                     break;
@@ -162,7 +170,8 @@ namespace BeatmapExporterGUI.ViewModels
             Description = $"Exporting audio from {TotalSetCount} beatmap sets as .mp3 files.\n{lazer.AudioTranscodeInfo()}";
 
             int exportedAudio = 0, discovered = 0;
-            foreach (var mapset in lazer.SelectedBeatmapSets)
+            var setsToExport = await Exporter.RealmScheduler.Schedule(() => OrderedSelectedSets().ToList());
+            foreach (var mapset in setsToExport)
             {
                 if (token.IsCancellationRequested)
                     break;
@@ -234,7 +243,8 @@ namespace BeatmapExporterGUI.ViewModels
             Description = $"Exporting beatmap background images from {TotalSetCount} beatmap sets.";
 
             int discovered = 0, exportedBackgrounds = 0;
-            foreach (var mapset in lazer.SelectedBeatmapSets)
+            var setsToExport = await Exporter.RealmScheduler.Schedule(() => OrderedSelectedSets().ToList());
+            foreach (var mapset in setsToExport)
             {
                 if (token.IsCancellationRequested)
                     break;
@@ -289,7 +299,11 @@ namespace BeatmapExporterGUI.ViewModels
         {
             lazer.SetupExport();
 
-            var selectedReplays = await Exporter.RealmScheduler.Schedule(() => lazer.GetSelectedReplays().ToList());
+            var selectedReplays = await Exporter.RealmScheduler.Schedule(() =>
+                OrderedSelectedSets()
+                    .SelectMany(s => s.SelectedBeatmaps)
+                    .SelectMany(b => b.Scores)
+                    .ToList());
             var replayCount = selectedReplays.Count();
             TotalCount = replayCount;
 

--- a/BeatmapExporterGUI/ViewModels/Settings/ExportConfigViewModel.cs
+++ b/BeatmapExporterGUI/ViewModels/Settings/ExportConfigViewModel.cs
@@ -169,6 +169,7 @@ namespace BeatmapExporterGUI.ViewModels.Settings
                 OnPropertyChanged(nameof(IsAudioExport));
                 OnPropertyChanged(nameof(IsCollectionDbExport));
                 OnPropertyChanged(nameof(ShouldDisplayMergeOptions));
+                OnPropertyChanged(nameof(SortApplicable));
             }
         }
 
@@ -297,6 +298,12 @@ namespace BeatmapExporterGUI.ViewModels.Settings
         /// Description of the current <see cref="MergeCaseInsensitive" /> setting, suitable for user display.
         /// </summary>
         public string MergeCaseDescriptor => MergeCaseInsensitive ? "Collections with the same name with different capitalization will be merged." : "Collections will not be merged, all collections are preserved.";
+
+        /// <summary>
+        /// If the sort toggle is meaningful for the current export format.
+        /// Skins and CollectionDb don't iterate beatmap sets, so the sort has no effect there.
+        /// </summary>
+        public bool SortApplicable => Config.ExportFormat is not (ExportFormat.Skins or ExportFormat.CollectionDb);
 
         /// <summary>
         /// If exported beatmap sets should be ordered by DateAdded instead of the default OnlineID order.

--- a/BeatmapExporterGUI/ViewModels/Settings/ExportConfigViewModel.cs
+++ b/BeatmapExporterGUI/ViewModels/Settings/ExportConfigViewModel.cs
@@ -299,6 +299,26 @@ namespace BeatmapExporterGUI.ViewModels.Settings
         public string MergeCaseDescriptor => MergeCaseInsensitive ? "Collections with the same name with different capitalization will be merged." : "Collections will not be merged, all collections are preserved.";
 
         /// <summary>
+        /// If exported beatmap sets should be ordered by DateAdded instead of the default OnlineID order.
+        /// </summary>
+        public bool SortByDateAdded
+        {
+            get => Config.SortByDateAdded;
+            set
+            {
+                Config.SortByDateAdded = value;
+                OnPropertyChanged(nameof(SortByDateAddedDescriptor));
+            }
+        }
+
+        /// <summary>
+        /// Description of the current <see cref="SortByDateAdded" /> setting, suitable for user display.
+        /// </summary>
+        public string SortByDateAddedDescriptor => SortByDateAdded
+            ? "Exports will be ordered by date added (oldest first)."
+            : "Exports will use the default order (by online beatmap ID).";
+
+        /// <summary>
         /// String containing the current type of file that will be exported
         /// </summary>
         public string ExportUnit => Config.ExportFormat.UnitName();

--- a/BeatmapExporterGUI/Views/Settings/ExportConfigView.axaml
+++ b/BeatmapExporterGUI/Views/Settings/ExportConfigView.axaml
@@ -188,6 +188,20 @@
 
       </StackPanel>
 
+      <!-- Sort by Date Added toggle -->
+      <StackPanel Spacing="6">
+
+        <StackPanel Orientation="Horizontal"
+                    Spacing="12">
+
+          <TextBlock VerticalAlignment="Center">Sort export by date added</TextBlock>
+          <CheckBox IsChecked="{Binding SortByDateAdded}" />
+
+        </StackPanel>
+        <TextBlock Text="{Binding SortByDateAddedDescriptor}" />
+
+      </StackPanel>
+
       <Button Command="{Binding ExportBeatmapsCommand}"
               Classes="accent"
               FontSize="18"

--- a/BeatmapExporterGUI/Views/Settings/ExportConfigView.axaml
+++ b/BeatmapExporterGUI/Views/Settings/ExportConfigView.axaml
@@ -189,7 +189,8 @@
       </StackPanel>
 
       <!-- Sort by Date Added toggle -->
-      <StackPanel Spacing="6">
+      <StackPanel Spacing="6"
+                  IsVisible="{Binding SortApplicable}">
 
         <StackPanel Orientation="Horizontal"
                     Spacing="12">


### PR DESCRIPTION
i just needed to sort beatmaps by adding date instead of an id, feel free to close / comment (i will address it) / alter it 

simply adds this checkbox that is set to false by default

<img width="733" height="526" alt="image" src="https://github.com/user-attachments/assets/bdfb4c44-7ca0-4f90-8f7b-a2fec2797c00" />

worked for me on dessktop and cli on kubuntu 26.04

matches my osu by date added sorting 

thanks for your work ! @kabiiQ 